### PR TITLE
missing colon in uniqueness

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -9,7 +9,7 @@ class Review < ApplicationRecord
   validates :rating, numericality: { only_integer: true }
   validates :rating, format: { with: /\A[0-5]?\z/,
     message: "only allows rating from 0 to 5" }
-  validates :user_id, uniqueness { scope: :request_id,
+  validates :user_id, uniqueness: { scope: :request_id,
     message: "only one review per rental experience" }
 
 end


### PR DESCRIPTION
validates :user_id, uniqueness: { scope: :request_id,
    message: "only one review per rental experience" }